### PR TITLE
Security: Override axios to 1.12.0 to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,10 @@
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios": "1.12.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: 1.12.0
+
 importers:
 
   .:
@@ -2458,8 +2461,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+  axios@1.12.0:
+    resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -8274,7 +8277,7 @@ snapshots:
   '@stellar/stellar-sdk@14.0.0-rc.3':
     dependencies:
       '@stellar/stellar-base': 14.0.0-rc.2
-      axios: 1.11.0
+      axios: 1.12.0
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -9057,7 +9060,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.11.0:
+  axios@1.12.0:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.4


### PR DESCRIPTION
# Security: Override axios to 1.12.0 to fix DoS vulnerability

## Summary
This PR adds a pnpm override to force all axios dependencies to version 1.12.0, addressing a Dependabot security alert for a DoS vulnerability in earlier axios versions.

The application currently uses axios 1.11.0 as a transitive dependency through @stellar/stellar-sdk. By adding the pnpm override, all axios instances throughout the dependency tree will be upgraded to the secure 1.12.0 version.

## Review & Testing Checklist for Human
- [ ] **Application starts and runs normally** - Verify the dev server starts without errors
- [ ] **Core user flows work correctly** - Test key features that make HTTP requests (wallet connections, API calls)
- [ ] **No new console errors or warnings** - Check browser dev tools and server logs for unexpected issues

### Notes
- axios 1.12.0 is backward compatible with 1.11.0 according to release notes
- This change affects transitive dependencies only - no direct axios usage in the codebase
- The override ensures consistent axios version across all dependencies

Session: https://app.devin.ai/sessions/bf609251d888444a94f5721a1ad5292c  
Requested by: @soinclined